### PR TITLE
build.sh: Account for SMT when calculating number of jobs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,12 @@ KERNEL_NAME="Popcorn"
 DATE=$(date +"%d-%m-%Y-%I-%M")
 FINAL_ZIP=$KERNEL_NAME-$DATE.zip
 
+if [ "$(cat /sys/devices/system/cpu/smt/active)" = "1" ]; then
+                export THREADS=$(expr $(nproc --all) \* 2)
+        else
+                export THREADS=$(nproc --all)
+        fi
+
 ## Funtions
 # Clean Compile
 function clean_compile() {
@@ -15,7 +21,7 @@ echo "---------------------------------------"
 make O=out ARCH=arm64 popcorn_defconfig
 
 PATH="/media/Data/Nokia/clang/bin:/media/Data/Nokia/arm64-gcc/bin:/media/Data/Nokia/arm-gcc/bin:${PATH}" \
-make -j$(nproc --all) O=out \
+make -j$THREADS O=out \
                       ARCH=arm64 \
                       CC=clang \
                       CLANG_TRIPLE=aarch64-linux-gnu- \
@@ -30,7 +36,7 @@ echo "---------------------------------------"
 make O=out ARCH=arm64 popcorn_defconfig
 
 PATH="/media/Data/Nokia/clang/bin:/media/Data/Nokia/arm64-gcc/bin:/media/Data/Nokia/arm-gcc/bin:${PATH}"
-make -j$(nproc --all) O=out \
+make -j$THREADS O=out \
                       ARCH=arm64 \
                       CC=clang \
                       CLANG_TRIPLE=aarch64-linux-gnu- \


### PR DESCRIPTION
nproc only returns number of physical cores when used with --all and does not account for threads. Check if the CPU is SMT active and if yes, multiply the number of cores returned by nproc by 2. Otherwise keep job count = no of cores.